### PR TITLE
Add Congressional Stock Brain to Service APIs section

### DIFF
--- a/markets/datasets.md
+++ b/markets/datasets.md
@@ -79,6 +79,7 @@ Kaggle datasets list (unsuitable to production systems, but Ok for research or e
 - [Intrinio API](https://docs.intrinio.com/documentation/) `#market-data` `#fundamentals` `#SEC`
 - [Rank and Fiels](http://rankandfiled.com/#/data/tickers) `#SEC` `#reports`
 - [OpenEDGAR](https://github.com/LexPredict/openedgar) `#SEC` `#reports` `#open-source` `#free`
+- - [Congressional Stock Brain](https://congressionalstockbrain.com) `#government` `#STOCK-Act` `#free`
 - [FMP API](https://financialmodelingprep.com/developer/) `#market-data` `#free`
 - [Markets Stack](https://marketstack.com/documentation) `#market-data`
 - [FTX API](https://docs.ftx.com/#overview) `#crypto` `#algo-trading` `#market-data` `#spot` `#futures`

--- a/markets/datasets.md
+++ b/markets/datasets.md
@@ -10,7 +10,7 @@ _List of datasets and service APIs with __Financial Markets__ data._
   - [OSINT](#osint)
 - [News Aggregators](#news-aggregators)
   - [Fundraising](#fundraising)
-  - [LLMs](#llms)h
+  - [LLMs](#llms)
 
 
 ## Datasets

--- a/markets/datasets.md
+++ b/markets/datasets.md
@@ -10,7 +10,7 @@ _List of datasets and service APIs with __Financial Markets__ data._
   - [OSINT](#osint)
 - [News Aggregators](#news-aggregators)
   - [Fundraising](#fundraising)
-  - [LLMs](#llms)
+  - [LLMs](#llms)h
 
 
 ## Datasets
@@ -79,7 +79,7 @@ Kaggle datasets list (unsuitable to production systems, but Ok for research or e
 - [Intrinio API](https://docs.intrinio.com/documentation/) `#market-data` `#fundamentals` `#SEC`
 - [Rank and Fiels](http://rankandfiled.com/#/data/tickers) `#SEC` `#reports`
 - [OpenEDGAR](https://github.com/LexPredict/openedgar) `#SEC` `#reports` `#open-source` `#free`
-- - [Congressional Stock Brain](https://congressionalstockbrain.com) `#government` `#STOCK-Act` `#free`
+- [Congressional Stock Brain](https://congressionalstockbrain.com) `#government` `#STOCK-Act` `#free`
 - [FMP API](https://financialmodelingprep.com/developer/) `#market-data` `#free`
 - [Markets Stack](https://marketstack.com/documentation) `#market-data`
 - [FTX API](https://docs.ftx.com/#overview) `#crypto` `#algo-trading` `#market-data` `#spot` `#futures`


### PR DESCRIPTION
Adding Congressional Stock Brain to the Service APIs section alongside other SEC/government data APIs (Rank and Fiels, OpenEDGAR, FMP API).

**Congressional Stock Brain** (https://congressionalstockbrain.com) is a free AI-powered fintech tool that ingests all U.S. STOCK Act disclosures — the mandatory public financial trade filings from U.S. lawmakers required under federal law — and converts them into machine-scored trade signals for retail investors.

- **Data source**: U.S. House & Senate STOCK Act filings (100% public government data)
- - **Free**: Yes, core features free with no login required
- - **AI layer**: Scores each disclosure by committee relevance, trade timing vs. legislative activity, and disclosure delay
- - **Tags**: #government #STOCK-Act #free
Fits alongside OpenEDGAR and Rank and Fiels as a government/regulatory data source in the Service APIs section.